### PR TITLE
Bugfix: Do not copy default gems, because they are already included in the jruby jars standard library

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -86,7 +86,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
-        tag_name: ${{ $JARBLER_RELEASE }}
+        tag_name: ${{ env.JARBLER_RELEASE }}
         release_name: Release ${{ github.ref }}
         draft: false
         prerelease: false

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -57,35 +57,42 @@ jobs:
       with:
         ruby-version: '3.1'
 
-#    - name: Publish to GPR
-#      run: |
-#        mkdir -p $HOME/.gem
-#        touch $HOME/.gem/credentials
-#        chmod 0600 $HOME/.gem/credentials
-#        printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-#        gem build *.gemspec
-#        gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
-#      env:
-#        GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
-#        OWNER: ${{ github.repository_owner }}
-
-    - name: Build and publish to RubyGems
+    - name: Build
       run: |
         mkdir -p $HOME/.gem
         touch $HOME/.gem/credentials
         chmod 0600 $HOME/.gem/credentials
         printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
         gem build jarbler.gemspec
-        RELEASE=`ls jarbler-*.gem | sed 's/jarbler-//' | sed 's/\.gem//'`
-        echo "Checking rubygems.org for RELEASE=$RELEASE"
+        JARBLER_RELEASE=`ls jarbler-*.gem | sed 's/jarbler-//' | sed 's/\.gem//'`
+        echo "JARBLER_RELEASE=$JARBLER_RELEASE" >> $GITHUB_ENV
+        echo "Checking rubygems.org for RELEASE=$JARBLER_RELEASE"
         set +e
-        gem search jarbler | grep jarbler | grep $RELEASE
+        gem search jarbler | grep jarbler | grep $JARBLER_RELEASE
         if [[ $? -eq 0 ]]; then
-          echo "RELEASE=$RELEASE already exists on rubygems.org, no push executed"
+          echo "RELEASE=$JARBLER_RELEASE already exists on rubygems.org, no push executed"
         else
-          echo "RELEASE=$RELEASE does not exist on rubygems.org yet, pushing..."
-          rdoc --all --ri --op doc
-          gem push *.gem
+          echo "RELEASE=$JARBLER_RELEASE does not exist on rubygems.org yet"
+          echo "Manual execution of 'gem push *.gem' required"
+          # rdoc --all --ri --op doc
+          # gem push *.gem
         fi
+      # env:
+        # GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
       env:
-        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        tag_name: ${{ JARBLER_RELEASE }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Put gem file into artifact
+      if: always()
+      uses: actions/upload-artifact@v1
+      with:
+        path: jarbler-*.gem

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -86,7 +86,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
-        tag_name: ${{ JARBLER_RELEASE }}
+        tag_name: ${{ $JARBLER_RELEASE }}
         release_name: Release ${{ github.ref }}
         draft: false
         prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.1.6] - 2023-06-19
+
+- Bugfix: Do not clone default gems, because they are already included in the jruby jars standard library
+
 ## [0.1.5] - 2023-06-15
 
 - Bugfix: use minor ruby version without patch level for Gem files location

--- a/build_gem.sh
+++ b/build_gem.sh
@@ -3,7 +3,7 @@
 # remove existing gem file
 rm -f jarbler-*.gem
 
-rake test
+bundle exec rake test
 if [ $? -ne 0 ]; then
   echo "Tests failed."
   exit 1

--- a/lib/jarbler/builder.rb
+++ b/lib/jarbler/builder.rb
@@ -121,9 +121,11 @@ module Jarbler
           # Copy the Gem from bundler/gems including the gemspec
           file_utils_copy(spec.gem_dir, "#{gem_target_location}/bundler/gems")
         else  # Gem is from rubygems
-          # copy the Gem and gemspec separately
-          file_utils_copy(spec.gem_dir, "#{gem_target_location}/gems")
-          file_utils_copy("#{spec.gem_dir}/../../specifications/#{needed_gem[:full_name]}.gemspec", "#{gem_target_location}/specifications")
+          unless spec.default_gem?  # Do not copy default gems, because they are already included in the jruby jars standard library
+            # copy the Gem and gemspec separately
+            file_utils_copy(spec.gem_dir, "#{gem_target_location}/gems")
+            file_utils_copy("#{spec.gem_dir}/../../specifications/#{needed_gem[:full_name]}.gemspec", "#{gem_target_location}/specifications")
+          end
         end
       end
     end

--- a/lib/jarbler/version.rb
+++ b/lib/jarbler/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Jarbler
-  VERSION = "0.1.5"
-  VERSION_DATE = "2023-06-15"
+  VERSION = "0.1.6"
+  VERSION_DATE = "2023-06-19"
 end


### PR DESCRIPTION
Bugfix: Do not copy default gems, because they are already included in the jruby jars standard library