### PR TITLE
Use the absolute path of the jar file for extraction, especially if i…

### DIFF
--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -56,9 +56,12 @@ class JarMain {
                 jarPath = jarPath.substring(1); // remove the leading slash
             }
 
+            // get the absolute path of the jar file, especially if it contains spaces in Windows
+            String aboluteJarPath = new File(jarPath).getAbsolutePath();
+
             // extract the jarFile by unzipping it (not using the jar utility which may not be available)
-            System.out.println("Extracting files from "+jarPath+" to "+ newFolder.getAbsolutePath());
-            unzip(jarPath, newFolder.getAbsolutePath());
+            System.out.println("Extracting files from "+aboluteJarPath+" to "+ newFolder.getAbsolutePath());
+            unzip(aboluteJarPath, newFolder.getAbsolutePath());
 
             String app_root = newFolder.getAbsolutePath()+File.separator+"app_root";
 

--- a/lib/jarbler/version.rb
+++ b/lib/jarbler/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Jarbler
-  VERSION = "0.3.1"
-  VERSION_DATE = "2024-07-02"
+  VERSION = "0.3.2"
+  VERSION_DATE = "2025-03-01"
 end


### PR DESCRIPTION
…t contains spaces in Windows