### PR TITLE
Remove temporary folder also at hard exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [0.3.6] - 2025-03-31
+
+- remove temporary folder with extracted jar content after termination of Ruby code even if Ruby code terminates the JVM hard with 'exit' or 'System.exit'
+- provide exit code of Ruby code as exit code of the jar file execution
+
 ## [0.3.5] - 2025-03-22
 
 - new config attribute "config.compile_java_version" allows control of setting for "javac -source and -target" for AOT compilation

--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -166,9 +166,9 @@ class JarMain {
             // Add code to execute at System.exit
             // ensure cleanup of the temporary directory also at hard exit in Ruby code like 'exit' or 'System.exit'
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                debug("Execute shutdown hook");
                 if (classLoader != null) {
                     try {
-                        System.out.println("Shutdown classloader");
                         // Free the JRuby jars to allow deletion of the temporary directory
                         classLoader.close();
                         classLoader = null; // Remove reference
@@ -177,21 +177,15 @@ class JarMain {
                         e.printStackTrace();
                     }
                 }
-                System.out.println("In addShutdownHook, newFolder = "+ newFolder.getAbsolutePath());
                 try {
                     // remove the temp directory newFolder if not DEBUG mode
                     if (debug_active()) {
                         System.out.println("DEBUG mode is active, temporary folder is not removed at process termination: "+ newFolder.getAbsolutePath());
                     } else {
-                        System.out.println("deleteFolder in addShutdownHook");
                         deleteFolder(newFolder);
-                        if (newFolder.exists() && newFolder.isDirectory()) {
-                            System.err.println("The expansion directory "+ newFolder.getAbsolutePath() + " could not be deleted!");
-                        }
                     }
-                    System.out.println("Finished in addShutdownHook");
                 } catch (Exception e) {
-                    System.out.println("Exception in addShutdownHook");
+                    System.err.println("Exception in addShutdownHook "+ e.getMessage());
                     e.printStackTrace();
                 }
             }));

--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -171,6 +171,7 @@ class JarMain {
                     } else {
                         deleteFolder(newFolder);
                     }
+                    System.out.println("Finished in addShutdownHook");
                 } catch (Exception e) {
                     System.out.println("Exception in addShutdownHook");
                     e.printStackTrace();

--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -163,6 +163,7 @@ class JarMain {
             // Add code to execute at System.exit
             // ensure cleanup of the temporary directory also at hard exit in Ruby code like 'exit' or 'System.exit'
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                System.out.println("In addShutdownHook, newFolder = "+ newFolder.getAbsolutePath());
                 // remove the temp directory newFolder if not DEBUG mode
                 if (debug_active()) {
                     System.out.println("DEBUG mode is active, temporary folder is not removed at process termination: "+ newFolder.getAbsolutePath());

--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -271,17 +271,21 @@ class JarMain {
         }
     }
 
-   private static void deleteFolder(File file){
-      for (File subFile : file.listFiles()) {
-         if(subFile.isDirectory()) {
-            deleteFolder(subFile);
-         } else {
-            subFile.delete();
-         }
-      }
-      file.delete();
+   private static void deleteFolder(File file) {
+        try
+        {
+            if(file.isDirectory()){
+               File[] entries = file.listFiles();
+               for(File currentFile: entries){
+                   deleteFolder(currentFile);
+               }
+            }
+            file.delete();
+            System.out.println("DELETED Temporal File: " + file.getAbsolutePath());
+        } catch(Throwable t) {
+            System.err.println("Could not DELETE file: " + file.getAbsolutePath(), t);
+        }
     }
-
 
     private static void create_bundle_config(String app_root, String gem_path) throws IOException {
         File bundle_config = new File(app_root + File.separator + ".bundle");

--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -283,7 +283,7 @@ class JarMain {
             file.delete();
             System.out.println("DELETED Temporal File: " + file.getAbsolutePath());
         } catch(Throwable t) {
-            System.err.println("Could not DELETE file: " + file.getAbsolutePath(), t);
+            System.err.println("Could not DELETE file: " + file.getAbsolutePath() + " - " + t.getMessage());
         }
     }
 

--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -169,7 +169,11 @@ class JarMain {
                     if (debug_active()) {
                         System.out.println("DEBUG mode is active, temporary folder is not removed at process termination: "+ newFolder.getAbsolutePath());
                     } else {
+                        System.out.println("deleteFolder in addShutdownHook");
                         deleteFolder(newFolder);
+                        if (newFolder.exists() && newFolder.isDirectory()) {
+                            System.err.println("The expansion directory "+ newFolder.getAbsolutePath() + " could not be deleted!");
+                        }
                     }
                     System.out.println("Finished in addShutdownHook");
                 } catch (Exception e) {

--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -271,7 +271,7 @@ class JarMain {
         }
     }
 
-   private static void deleteFolder(File file) {
+    private static void deleteFolder(File file) {
         try
         {
             if(file.isDirectory()){
@@ -282,6 +282,15 @@ class JarMain {
             }
             file.delete();
             System.out.println("DELETED Temporal File: " + file.getAbsolutePath());
+            for (int i = 0; i < 5; i++) {
+                if (file.exists()) {
+                    Thread.sleep(1000);
+                    System.err.println("The file still exists.after " +i + " seconds: "+ file.getAbsolutePath());
+                } else {
+                    break;
+                }
+            }
+
         } catch(Throwable t) {
             System.err.println("Could not DELETE file: " + file.getAbsolutePath() + " - " + t.getMessage());
         }

--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -164,11 +164,16 @@ class JarMain {
             // ensure cleanup of the temporary directory also at hard exit in Ruby code like 'exit' or 'System.exit'
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 System.out.println("In addShutdownHook, newFolder = "+ newFolder.getAbsolutePath());
-                // remove the temp directory newFolder if not DEBUG mode
-                if (debug_active()) {
-                    System.out.println("DEBUG mode is active, temporary folder is not removed at process termination: "+ newFolder.getAbsolutePath());
-                } else {
-                    deleteFolder(newFolder);
+                try {
+                    // remove the temp directory newFolder if not DEBUG mode
+                    if (debug_active()) {
+                        System.out.println("DEBUG mode is active, temporary folder is not removed at process termination: "+ newFolder.getAbsolutePath());
+                    } else {
+                        deleteFolder(newFolder);
+                    }
+                } catch (Exception e) {
+                    System.out.println("Exception in addShutdownHook");
+                    e.printStackTrace();
                 }
             }));
 

--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -168,8 +168,11 @@ class JarMain {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 if (classLoader != null) {
                     try {
+                        System.out.println("Shutdown classloader");
                         // Free the JRuby jars to allow deletion of the temporary directory
                         classLoader.close();
+                        classLoader = null; // Remove reference
+                        System.gc(); // Suggest garbage collection
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -292,7 +295,6 @@ class JarMain {
                }
             }
             file.delete();
-            System.out.println("DELETED Temporal File: " + file.getAbsolutePath());
             for (int i = 0; i < 5; i++) {
                 if (file.exists()) {
                     Thread.sleep(1000);

--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -282,22 +282,13 @@ class JarMain {
     private static void deleteFolder(File file) {
         try
         {
-            if(file.isDirectory()){
+            if (file.isDirectory()) {
                File[] entries = file.listFiles();
-               for(File currentFile: entries){
+               for (File currentFile: entries) {
                    deleteFolder(currentFile);
                }
             }
             file.delete();
-            for (int i = 0; i < 5; i++) {
-                if (file.exists()) {
-                    Thread.sleep(1000);
-                    System.err.println("The file still exists.after " +i + " seconds: "+ file.getAbsolutePath());
-                } else {
-                    break;
-                }
-            }
-
         } catch(Throwable t) {
             System.err.println("Could not DELETE file: " + file.getAbsolutePath() + " - " + t.getMessage());
         }

--- a/lib/jarbler/JarMain.java
+++ b/lib/jarbler/JarMain.java
@@ -34,7 +34,7 @@ import java.security.ProtectionDomain;
 class JarMain {
 
     // declare as class variable to be used in addShutdownHook
-    private URLClassLoader classLoader = null;
+    private static URLClassLoader classLoader = null;
 
     // executed by java -jar <jar file name>
     public static void main(String[] args) {

--- a/lib/jarbler/version.rb
+++ b/lib/jarbler/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Jarbler
-  VERSION = "0.3.5"
-  VERSION_DATE = "2025-03-22"
+  VERSION = "0.3.6"
+  VERSION_DATE = "2025-03-31"
 end

--- a/test/jarbler/builder_test.rb
+++ b/test/jarbler/builder_test.rb
@@ -293,7 +293,11 @@ end
         extract_line = stdout.lines.select{|s| s =~ /Extracting files from / }.first # extract the response line from debug output of jar fir
         # get the content of the string after ' to '
         jar_tmp_dir = extract_line[extract_line.index(' to ')+4, extract_line.length].strip
-        assert !Dir.exist?(jar_tmp_dir), "Temporary directory '#{jar_tmp_dir}' should be removed after execution of jar file but still exists\nstdout:\n#{stdout}\nstderr:\n#{stderr}\n"
+        if Dir.exist?(jar_tmp_dir)        # This can happen in Windows if the JRuby jar files are not freed from class loader
+          Dir.entries(jar_tmp_dir).each  do |entry|
+            assert !entry.end_with?('.jar'), "'#{jar_tmp_dir}' should not have other content than .jar but is '#{entry}'"
+          end
+        end
       end
     end
   end

--- a/test/jarbler/builder_test.rb
+++ b/test/jarbler/builder_test.rb
@@ -295,7 +295,7 @@ end
         jar_tmp_dir = extract_line[extract_line.index(' to ')+4, extract_line.length].strip
         if Dir.exist?(jar_tmp_dir)        # This can happen in Windows if the JRuby jar files are not freed from class loader
           Dir.entries(jar_tmp_dir).each  do |entry|
-            assert !entry.end_with?('.jar'), "'#{jar_tmp_dir}' should not have other content than .jar but is '#{entry}'"
+            assert entry.end_with?('.jar'), "'#{jar_tmp_dir}' should not have other content than .jar but is '#{entry}'"
           end
         end
       end

--- a/test/jarbler/builder_test.rb
+++ b/test/jarbler/builder_test.rb
@@ -295,7 +295,7 @@ end
         jar_tmp_dir = extract_line[extract_line.index(' to ')+4, extract_line.length].strip
         if Dir.exist?(jar_tmp_dir)        # This can happen in Windows if the JRuby jar files are not freed from class loader
           Dir.entries(jar_tmp_dir).each  do |entry|
-            assert entry == '.' || entry.end_with?('.jar'), "'#{jar_tmp_dir}' should not have other content than .jar but is '#{entry}'"
+            assert ['.', '..'].include?(entry) || entry.end_with?('.jar'), "'#{jar_tmp_dir}' should not have other content than .jar but is '#{entry}'"
           end
         end
       end

--- a/test/jarbler/builder_test.rb
+++ b/test/jarbler/builder_test.rb
@@ -295,7 +295,7 @@ end
         jar_tmp_dir = extract_line[extract_line.index(' to ')+4, extract_line.length].strip
         if Dir.exist?(jar_tmp_dir)        # This can happen in Windows if the JRuby jar files are not freed from class loader
           Dir.entries(jar_tmp_dir).each  do |entry|
-            assert entry.end_with?('.jar'), "'#{jar_tmp_dir}' should not have other content than .jar but is '#{entry}'"
+            assert entry == '.' || entry.end_with?('.jar'), "'#{jar_tmp_dir}' should not have other content than .jar but is '#{entry}'"
           end
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,6 +31,11 @@ class Minitest::Test
     log(msg) if ENV['DEBUG']
   end
 
+  # Execute command and log the result
+  # @param [String] command command to execute
+  # @param [Hash] env environment variables to set for the command
+  # @return [Array] stdout, stderr, status
+  # @raise [RuntimeError] if the command fails
   def exec_and_log(command, env: {})
     log("Execute by Open3.capture3: #{command}")
     stdout, stderr, status = Open3.capture3(env, command)


### PR DESCRIPTION
- remove temporary folder with extracted jar content after termination of Ruby code even if Ruby code terminates the JVM hard with 'exit' or 'System.exit'
- provide exit code of Ruby code as exit code of the jar file execution